### PR TITLE
Handle ApplicationController#current_user

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+task default: :test
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
+end

--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -9,7 +9,7 @@ module Pretender
     impersonated_var = :"@impersonated_#{scope}"
 
     # define methods
-    if respond_to?(impersonated_method)
+    if method_defined?(impersonated_method)
       alias_method true_method, impersonated_method
     else
       define_method true_method do

--- a/pretender.gemspec
+++ b/pretender.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "activesupport"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,29 @@
+require "minitest/autorun"
+require "minitest/pride"
+require "active_support/core_ext/string/inflections"
+
+User = Struct.new(:id) do
+  def self.where(id: nil)
+    [new(id)]
+  end
+end
+
+module ActionController
+  class Base
+    attr_reader :session
+    attr_accessor :current_user
+
+    def initialize
+      @session = {}
+    end
+
+    def self.helper_method(*)
+    end
+  end
+end
+
+require_relative "../lib/pretender"
+
+class ApplicationController < ActionController::Base
+  impersonates :user
+end

--- a/test/pretender_test.rb
+++ b/test/pretender_test.rb
@@ -1,0 +1,60 @@
+require_relative "helper"
+
+module TheTruth
+  def test_original_state
+    @controller.current_user = @impersonator
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonator, @controller.current_user
+  end
+
+  def test_impersonates
+    @controller.current_user = @impersonator
+    @controller.impersonate_user @impersonated
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonated, @controller.current_user
+  end
+
+  def test_impersonated_state
+    @controller.current_user = @impersonator
+    @controller.session[:impersonated_user_id] = @impersonated.id
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonated, @controller.current_user
+  end
+
+  def test_stops_impersonating
+    @controller.current_user = @impersonator
+    @controller.session[:impersonated_user_id] = @impersonated.id
+    @controller.stop_impersonating_user
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonator, @controller.current_user
+  end
+end
+
+class PretenderTest < Minitest::Test
+  include TheTruth
+
+  def setup
+    @impersonator = User.new("impersonator")
+    @impersonated = User.new("impersonated")
+    @controller = ApplicationController.new
+  end
+end
+
+class SuperPretenderTest < Minitest::Test
+  include TheTruth
+
+  def setup
+    @impersonator = User.new("impersonator")
+    @impersonated = User.new("impersonated")
+    @controller = ApplicationController.new
+    class << @controller
+      def current_user
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch handles the use case where #current_user in the Base class is overridden in Application Controller.

I also added tests.
