### PR TITLE
Allow custom primary key

### DIFF
--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -6,7 +6,7 @@ module Pretender
 
   def impersonates(scope = :user, opts = {})
     impersonated_method = opts[:method] || :"current_#{scope}"
-    impersonate_with = opts[:with] || proc { |id| scope.to_s.classify.constantize.where(:id => id).first }
+    impersonate_with = opts[:with] || proc { |id| scope.to_s.classify.constantize.where(scope.to_s.classify.constantize.primary_key.to_sym => id).first }
     true_method = :"true_#{scope}"
     session_key = :"impersonated_#{scope}_id"
     impersonated_var = :"@impersonated_#{scope}"


### PR DESCRIPTION
With this change, the primary key is pulled from the model rather than assuming that ID is used as the primary key. This allows for a custom primary key.
