### PR TITLE
Enforce minimum ActiveRecord version

### DIFF
--- a/pretender.gemspec
+++ b/pretender.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack"
+  spec.add_dependency "activerecord", ">= 4"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Recent changes allow to configure the primary key. This uses `ActiveRecord::Base#find_by`. However #find_by was introduced in Rails 4. Therefore we need to explicitly say we need a minimum of AR 4.