### PR TITLE
Stubbed User.find_by method in test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,10 @@ require "minitest/pride"
 require "action_controller"
 
 User = Struct.new(:id) do
+  def self.find_by(id: nil)
+    new(id)
+  end
+
   def self.where(id: nil)
     [new(id)]
   end


### PR DESCRIPTION
I found that there are some failure tests which is caused by undefined `find_by` method, so I stubbed it to fix the failures.