### PR TITLE
Set context of `with` proc to controller

### DIFF
--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -36,7 +36,7 @@ module Pretender
           if session[session_key] && !true_resource
             session[session_key] = nil
           end
-          value = (session[session_key] && impersonate_with.call(session[session_key])) || true_resource
+          value = (session[session_key] && self.instance_exec(session[session_key], &impersonate_with)) || true_resource
           instance_variable_set(impersonated_var, value) if value
         end
         instance_variable_get(impersonated_var)

--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -51,6 +51,11 @@ module Pretender
         instance_variable_set(impersonated_var, nil)
         session[session_key] = nil
       end
+
+      define_method :"impersonating_#{scope}?" do
+        send(true_method) != send(impersonated_method)
+      end
+      helper_method(:"impersonating_#{scope}?") if respond_to?(:helper_method)
     end
   end
 end

--- a/test/pretender_test.rb
+++ b/test/pretender_test.rb
@@ -58,3 +58,22 @@ class SuperPretenderTest < Minitest::Test
     end
   end
 end
+
+class ContextTest < MiniTest::Test
+  include TheTruth
+
+  def test_context
+    @controller.current_user = @impersonator
+    @controller.session[:impersonated_user_id] = @impersonated.id
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonated, @controller.current_user
+    assert_equal 'foo', @controller.context_test
+  end
+
+  def setup
+    @impersonator = User.new("impersonator")
+    @impersonated = User.new("impersonated")
+    @controller = ContextController.new
+  end
+end

--- a/test/pretender_test.rb
+++ b/test/pretender_test.rb
@@ -6,6 +6,7 @@ module TheTruth
 
     assert_equal @impersonator, @controller.true_user
     assert_equal @impersonator, @controller.current_user
+    refute @controller.impersonating_user?
   end
 
   def test_impersonates
@@ -14,6 +15,7 @@ module TheTruth
 
     assert_equal @impersonator, @controller.true_user
     assert_equal @impersonated, @controller.current_user
+    assert @controller.impersonating_user?
   end
 
   def test_impersonated_state
@@ -22,6 +24,7 @@ module TheTruth
 
     assert_equal @impersonator, @controller.true_user
     assert_equal @impersonated, @controller.current_user
+    assert @controller.impersonating_user?
   end
 
   def test_stops_impersonating
@@ -31,6 +34,7 @@ module TheTruth
 
     assert_equal @impersonator, @controller.true_user
     assert_equal @impersonator, @controller.current_user
+    refute @controller.impersonating_user?
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,3 +28,11 @@ class ApplicationController < ActionController::Base
   attr_accessor :current_user
   impersonates :user
 end
+
+class ContextController < ActionController::Base
+  attr_accessor :current_user, :context_test
+  impersonates :user, with: -> (id) do
+    self.context_test = 'foo'
+    User.find_by(id: id)
+  end
+end


### PR DESCRIPTION
Allow the `with` proc to use the context of the requested controller. Useful for allowing per-request validations of the impersonator/impersonated relationship

Also added `impersonating_#{scope}?` helper method to simplify use of `true_user != current_user` (or similar) throughout the codebase