### PR TITLE
Modified call to `with` proc to use controller as self context

### DIFF
--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -36,7 +36,7 @@ module Pretender
           if session[session_key] && !true_resource
             session[session_key] = nil
           end
-          value = (session[session_key] && impersonate_with.call(session[session_key])) || true_resource
+          value = (session[session_key] && self.instance_exec(session[session_key], &impersonate_with)) || true_resource
           instance_variable_set(impersonated_var, value) if value
         end
         instance_variable_get(impersonated_var)

--- a/test/pretender_test.rb
+++ b/test/pretender_test.rb
@@ -58,3 +58,22 @@ class SuperPretenderTest < Minitest::Test
     end
   end
 end
+
+class ContextTest < MiniTest::Test
+  include TheTruth
+
+  def test_context
+    @controller.current_user = @impersonator
+    @controller.session[:impersonated_user_id] = @impersonated.id
+
+    assert_equal @impersonator, @controller.true_user
+    assert_equal @impersonated, @controller.current_user
+    assert_equal 'foo', @controller.context_test
+  end
+
+  def setup
+    @impersonator = User.new("impersonator")
+    @impersonated = User.new("impersonated")
+    @controller = ContextController.new
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,3 +28,11 @@ class ApplicationController < ActionController::Base
   attr_accessor :current_user
   impersonates :user
 end
+
+class ContextController < ActionController::Base
+  attr_accessor :current_user, :context_test
+  impersonates :user, with: -> (id) do
+    self.context_test = 'foo'
+    User.find_by(id: id)
+  end
+end


### PR DESCRIPTION
Allow the `with` proc to use the context of the requested controller. Useful for allowing per-request validations of the impersonator/impersonated relationship

Example:

```
class ApplicationController < ActionController::Base
  impersonates :user, with: ->(id) do
    user = User.active_users.find_by(id: id)
    user if true_user.can_impersonate? user
  end
end
```