### PR TITLE
Convert resource.id to string for Mongoid compatibility

### DIFF
--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -44,7 +44,7 @@ module Pretender
 
       define_method :"impersonate_#{scope}" do |resource|
         instance_variable_set(impersonated_var, resource)
-        session[session_key] = resource.id
+        session[session_key] = resource.id.to_s
       end
 
       define_method :"stop_impersonating_#{scope}" do

--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -44,7 +44,7 @@ module Pretender
 
       define_method :"impersonate_#{scope}" do |resource|
         instance_variable_set(impersonated_var, resource)
-        session[session_key] = resource.id.to_s
+        session[session_key] = resource.id.is_a?(Numeric) ? resource.id : resource.id.to_s
       end
 
       define_method :"stop_impersonating_#{scope}" do


### PR DESCRIPTION
Hi! I tried to include this gem in my project that uses Mongoid and it failed because it tries to store in the session the user.id, which is a BSON::ObjectId, instead of storing just the Id as a string.

I've just added ".to_s" and it works perfectly.
