### PR TITLE
"[skip ci]" is supported by GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 on: [push, pull_request]
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

Edit: I believe this PR proves this works, since by putting it in the title, the workflow was indeed not executed. Was not intentional, though 😅. 