### PR TITLE
Allow for class names of impersonated object to differ from scope names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.tool-versions
 .yardoc
 InstalledFiles
 _yardoc

--- a/lib/pretender.rb
+++ b/lib/pretender.rb
@@ -7,13 +7,14 @@ module Pretender
   module Methods
     def impersonates(scope = :user, opts = {})
       impersonated_method = opts[:method] || :"current_#{scope}"
-      impersonate_with = opts[:with] || proc { |id|
-        klass = scope.to_s.classify.constantize
+      impersonate_with = opts[:with] || proc { |klass, id|
+        klass = klass.constantize
         primary_key = klass.respond_to?(:primary_key) ? klass.primary_key : :id
         klass.find_by(primary_key => id)
       }
       true_method = :"true_#{scope}"
-      session_key = :"impersonated_#{scope}_id"
+      id_session_key = :"impersonated_#{scope}_id"
+      klass_session_key = :"impersonated_#{scope}_klass"
       impersonated_var = :"@impersonated_#{scope}"
       stop_impersonating_method = :"stop_impersonating_#{scope}"
 
@@ -33,14 +34,18 @@ module Pretender
       define_method impersonated_method do
         impersonated_resource = instance_variable_get(impersonated_var) if instance_variable_defined?(impersonated_var)
 
-        if !impersonated_resource && request.session[session_key]
+        if !impersonated_resource && request.session[id_session_key]
           # only fetch impersonation if user is logged in
           # this is a safety check (once per request) so
           # if a user logs out without session being destroyed
           # or stop_impersonating_user being called,
           # we can stop the impersonation
           if send(true_method)
-            impersonated_resource = impersonate_with.call(request.session[session_key])
+            impersonated_resource = if impersonate_with.arity == 1
+                                      impersonate_with.call(request.session[id_session_key])
+                                    else
+                                      impersonate_with.call(request.session[klass_session_key], request.session[id_session_key])
+                                    end
             instance_variable_set(impersonated_var, impersonated_resource) if impersonated_resource
           else
             # TODO better message
@@ -58,12 +63,14 @@ module Pretender
 
         instance_variable_set(impersonated_var, resource)
         # use to_s for Mongoid for BSON::ObjectId
-        request.session[session_key] = resource.id.is_a?(Numeric) ? resource.id : resource.id.to_s
+        request.session[id_session_key] = resource.id.is_a?(Numeric) ? resource.id : resource.id.to_s
+        request.session[klass_session_key] = resource.class.to_s
       end
 
       define_method stop_impersonating_method do
         remove_instance_variable(impersonated_var) if instance_variable_defined?(impersonated_var)
-        request.session.delete(session_key)
+        request.session.delete(id_session_key)
+        request.session.delete(klass_session_key)
       end
     end
   end

--- a/test/internal/app/controllers/customer_controller.rb
+++ b/test/internal/app/controllers/customer_controller.rb
@@ -1,0 +1,31 @@
+class CustomerController < ActionController::Base
+  def index
+    head :ok
+  end
+
+  def impersonate
+    impersonate_customer(CustomerFake.find_by!(name: "User"))
+    head :ok
+  end
+
+  def impersonate_custom_with
+    impersonate_account(Account.find_by!(name: "User"))
+  end
+
+  def stop_impersonating
+    stop_impersonating_customer
+    stop_impersonating_account
+    head :ok
+  end
+
+  def current_customer
+    @current_customer ||= CustomerFake.find_by!(name: "Admin")
+  end
+
+  def current_account
+    @current_account ||= Account.find_by!(name: "Admin")
+  end
+
+  impersonates :customer
+  impersonates :account, with: ->(id) { Account.find_by(id: id) }
+end

--- a/test/internal/app/controllers/home_controller.rb
+++ b/test/internal/app/controllers/home_controller.rb
@@ -3,6 +3,12 @@ class HomeController < ActionController::Base
     head :ok
   end
 
+  def setup_session
+    user = User.find_by!(name: "User")
+    request.session[:"impersonated_user_id"] = user.id
+    request.session[:"impersonated_user_klass"] = user.class.to_s
+  end
+
   def impersonate
     impersonate_user(User.find_by!(name: "User"))
     head :ok

--- a/test/internal/app/models/account.rb
+++ b/test/internal/app/models/account.rb
@@ -1,0 +1,2 @@
+class Account < ActiveRecord::Base
+end

--- a/test/internal/app/models/customer_fake.rb
+++ b/test/internal/app/models/customer_fake.rb
@@ -1,0 +1,2 @@
+class CustomerFake < ActiveRecord::Base
+end

--- a/test/internal/config/routes.rb
+++ b/test/internal/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   root "home#index"
   post "impersonate" => "home#impersonate"
+  post "setup_session" => "home#setup_session"
   post "stop_impersonating" => "home#stop_impersonating"
+
+  get "customer", to: "customer#index"
+  post "impersonate_customer" => "customer#impersonate"
+  post "stop_impersonating_customer" => "customer#stop_impersonating"
+  post "impersonate_custom_with" => "customer#impersonate_custom_with"
 end

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -2,4 +2,12 @@ ActiveRecord::Schema.define do
   create_table :users do |t|
     t.string :name
   end
+
+  create_table :customer_fakes do |t|
+    t.string :name
+  end
+
+  create_table :accounts do |t|
+    t.string :name
+  end
 end

--- a/test/pretender_test.rb
+++ b/test/pretender_test.rb
@@ -3,6 +3,8 @@ require_relative "test_helper"
 class PretenderTest < ActionDispatch::IntegrationTest
   def setup
     User.delete_all
+    CustomerFake.delete_all
+    Account.delete_all
   end
 
   def test_works
@@ -28,6 +30,63 @@ class PretenderTest < ActionDispatch::IntegrationTest
     assert_equal admin, true_user
   end
 
+  def test_non_matching_class_works
+    admin = CustomerFake.create!(name: "Admin")
+    user = CustomerFake.create!(name: "User")
+
+    get customer_url
+    assert_response :success
+
+    assert_equal admin, current_customer
+    assert_equal admin, true_customer
+
+    post impersonate_customer_url
+    assert_response :success
+
+    assert_equal user, current_customer
+    assert_equal admin, true_customer
+
+    post stop_impersonating_customer_url
+    assert_response :success
+
+    assert_equal admin, current_customer
+    assert_equal admin, true_customer
+  end
+
+  def test_session_works
+    admin = User.create!(name: "Admin")
+    user = User.create!(name: "User")
+
+    get root_url
+    assert_response :success
+
+    assert_equal admin, current_user
+    assert_equal admin, true_user
+
+    post setup_session_url
+    assert_response :success
+
+    assert_equal user, current_user
+    assert_equal admin, true_user
+  end
+
+  def test_old_style_with_statements
+    admin = Account.create!(name: "Admin")
+    user = Account.create!(name: "User")
+
+    get customer_url
+    assert_response :success
+
+    assert_equal admin, current_account
+    assert_equal admin, true_account
+
+    post impersonate_custom_with_url
+    assert_response :success
+
+    assert_equal user, current_account
+    assert_equal admin, true_account
+  end
+
   private
 
   def current_user
@@ -36,5 +95,21 @@ class PretenderTest < ActionDispatch::IntegrationTest
 
   def true_user
     controller.true_user
+  end
+
+  def current_customer
+    controller.current_customer
+  end
+
+  def true_customer
+    controller.true_customer
+  end
+
+  def current_account
+    controller.current_account
+  end
+
+  def true_account
+    controller.true_account
   end
 end


### PR DESCRIPTION
Thank you for sharing this very handy little tool!

I've run into a situation that I couldn't find a graceful solution to with pretender in its current implementation, namely if you have multiple different classes backing your `current_foo` call or if your scope does not match your underlying class name. It's possible you feel this flexibility is out of scope for what pretender focuses on, but it seemed like a reasonable extension to really give the end user free rein.

Assuming you're open to allowing this functionality I'd love suggestions of ways to add it. I put together this PR to drive out a possible path for your consideration and to familiarize myself a bit more with the code behind the scenes. I very well may have broken functional requirements you are aware of.

My approach was fairly straight forward, instead of only capturing the id of the resource passed in for impersonation, we also capture the class. This way we are attempting to restore the actual class provided originally instead of what the scope might imply. I added in some fallback logic around the old style of single argument `:with` optional parameters. I believe this change only breaks for people relying on impersonating an object of `classA` to cause `current_foo` to return `classFoo` instead of the impersonated `classA`. While this is possible it felt unlikely, and could be resolved by either passing in `classFoo` for impersonation or supplying their own custom `:with` to restore the previous functionality.

If we find a reasonable way to incorporate this change I'm willing to update the documentation and examples with the new information. I also drove out a few more tests around the session restoration feature and alternative flows to verify that I wouldn't inadvertently break existing functionality.

