### PR TITLE
Feat: Make Compatible with Spree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,6 @@
 ## 0.2.0 (2016-07-07)
 
 - Started changelog
+
+## 0.2.1 (2024-07-05)
+- Make Compatible with Spree

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+For Spree add this to your 'ApplicationController':
+...ruby
+class ApplicationController < ActionController::Base
+  impersonates :spree_user, spree: :true
+end
+...
+
 ## How It Works
 
 Sign in as another user with:

--- a/lib/pretender/version.rb
+++ b/lib/pretender/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Pretender
-  VERSION = "0.5.0"
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
**Description:**
This PR make the gem compatible with Spree gem base on the opts[:spree] flag

**Changes:**
1. Added a check on the base of spree flag
2. On the basis of the flag it called right resource from the database as spree table called with Spree::User
3. Resolved some rubocop issue

**Checklist:**
1. Tested locally
2. Mention the changes in the Read me 
3. Update the version
4. Update the changeLog.md file
5. Followed coding standards

**How to Test**
1. Ensure otps[:spree] is set to true in the application controller and observe the behavior
2. Ensure otps[:spree] is set to false in the application controller and observe the behavior
3. Skip to add otps[:spree] in the application controller and observe the behavior

**Screenshot**
In Spree Application
![image](https://github.com/ankane/pretender/assets/124498668/0fdfe8ae-34c1-4b3b-9c91-83d91ac05f1e)

In Normal Application
![image](https://github.com/ankane/pretender/assets/124498668/bacd1783-dee8-4ae5-aa47-aee4b6f5db2e)

